### PR TITLE
Try to prevent Renovate errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.5
 
       - name: Create dist
         run: |


### PR DESCRIPTION
# Description

Renovate is error'ing out with `Error updating branch: update failure` which is never super-explicit.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/parse-tool-versions/blob/main/CONTRIBUTING.md)
