### PR TITLE
Renovate: name a regex-based update string better

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
 
     env:
       # renovate datasource: docker, depName: hadolint/hadolint
-      hadolint: 2.12.0
+      hadolint-version: 2.12.0
 
     steps:
       - name: Checkout
@@ -23,7 +23,7 @@ jobs:
           npm run dist
 
       - name: Lint Dockerfile
-        run: docker run --rm -i hadolint/hadolint:${{ env.hadolint }} < Dockerfile
+        run: docker run --rm -i hadolint/hadolint:${{ env.hadolint-version }} < Dockerfile
 
       - name: Check if build left artifacts
         run: git diff --exit-code


### PR DESCRIPTION
# Description

Try to prevent further Renovate issue by renaming dep to something that most likely is not a depName.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/paulo-ferraz-oliveira/parse-tool-versions/blob/main/CONTRIBUTING.md)
